### PR TITLE
Fix notification open operation

### DIFF
--- a/Notifiable-iOS/Category/NSError+FWTNotifiable.h
+++ b/Notifiable-iOS/Category/NSError+FWTNotifiable.h
@@ -22,7 +22,8 @@ typedef NS_ENUM(NSInteger, FWTError) {
     FWTErrorInvalidOperation = -1004,
     FWTErrorUserAliasMissing,
     FWTErrorForbidden,
-    FWTErrorInvalidDeviceInformation
+    FWTErrorInvalidDeviceInformation,
+    FWTErrorInvalidNotification
 };
 
 @interface NSError (FWTNotifiable)
@@ -70,6 +71,14 @@ typedef NS_ENUM(NSInteger, FWTError) {
  @param underlyingError Original error.
  */
 + (instancetype) fwt_invalidDeviceInformationError:(NSError * _Nullable)underlyingError;
+/**
+ Create an error with the code FWTErrorInvalidNotification.
+ 
+ @see FWTError
+ 
+ @param underlyingError Original error.
+ */
++ (instancetype) fwt_invalidNotificationError:(NSError * _Nullable)underlyingError;
 
 - (NSString *) fwt_debugMessage;
 

--- a/Notifiable-iOS/Category/NSError+FWTNotifiable.m
+++ b/Notifiable-iOS/Category/NSError+FWTNotifiable.m
@@ -55,6 +55,13 @@ static NSString * const FWTNotifiableErrorDomain = @"com.futureworkshops.FWTNoti
                 andUnderlyingError:underlyingError];
 }
 
++ (instancetype) fwt_invalidNotificationError:(NSError * _Nullable)underlyingError
+{
+    return [self fwt_errorWithCode:FWTErrorInvalidNotification
+                       description:@"Notification without the localized_notification_id property."
+                andUnderlyingError:underlyingError];
+}
+
 #pragma mark - Private methods
 
 + (instancetype) fwt_errorWithCode:(NSInteger)code

--- a/Notifiable-iOS/FWTNotifiableManager.h
+++ b/Notifiable-iOS/FWTNotifiableManager.h
@@ -368,6 +368,15 @@ typedef void (^FWTNotifiableListOperationCompletionHandler)(NSArray<FWTNotifiabl
 - (void)applicationDidReceiveRemoteNotification:(NSDictionary *)notificationInfo;
 
 /**
+ Notify the server that a notification was read and listen for the server response
+ 
+ @param notificationInfo    The information of the notification given by the system
+ @param handler             Block called once that the operation is finished.
+*/
+- (void)applicationDidReceiveRemoteNotification:(NSDictionary *)notificationInfo
+                          withCompletionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
+
+/**
  Inform the Notifiable Manager that the application did register for remote notifications
  
  @param application Application that was registered

--- a/Notifiable-iOS/FWTNotifiableManager.m
+++ b/Notifiable-iOS/FWTNotifiableManager.m
@@ -457,21 +457,15 @@ NSString * const FWTNotifiableNotificationDeviceToken = @"FWTNotifiableNotificat
         return;
     }
     
-    NSMutableDictionary *requestParameters = [NSMutableDictionary dictionary];
-    
-    if(notificationID)
-        requestParameters[@"localized_notification_id"] = notificationID;
-    if (self.currentDevice.user) {
-        [requestParameters addEntriesFromDictionary:@{@"user":@{@"alias":self.currentDevice.user}}];
-    }
-    requestParameters[@"device_token_id"] = self.currentDevice.tokenId;
-    
     __weak typeof(self) weakSelf = self;
-    [self.requestManager markNotificationAsOpenedWithParams:requestParameters completionHandler:^(BOOL success, NSError * _Nullable error) {
-        if (handler) {
-            handler(weakSelf.currentDevice, error);
-        }
-    }];
+    [self.requestManager markNotificationAsOpened:notificationID
+                                          forUser:self.currentDevice.user
+                                 andDeviceTokenId:self.currentDevice.tokenId
+                            withCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+                                if (handler) {
+                                    handler(weakSelf.currentDevice, error);
+                                }
+                            }];
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(nonnull NSData *)deviceToken

--- a/Notifiable-iOS/FWTNotifiableManager.m
+++ b/Notifiable-iOS/FWTNotifiableManager.m
@@ -434,15 +434,44 @@ NSString * const FWTNotifiableNotificationDeviceToken = @"FWTNotifiableNotificat
 
 - (void)applicationDidReceiveRemoteNotification:(NSDictionary *)notificationInfo
 {
-    NSString *notificationID = notificationInfo[@"notification_id"];
+    [self applicationDidReceiveRemoteNotification:notificationInfo
+                            withCompletionHandler:nil];
+}
+
+- (void)applicationDidReceiveRemoteNotification:(NSDictionary *)notificationInfo
+                          withCompletionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler
+{
+    NSNumber *notificationID = notificationInfo[@"localized_notification_id"];
+    
+    if (notificationID == nil) {
+        if(handler) {
+            handler(self.currentDevice, [NSError fwt_invalidDeviceInformationError:nil]);
+        }
+        return;
+    }
+    
+    if(self.currentDevice == nil) {
+        if(handler) {
+            handler(self.currentDevice, [NSError fwt_invalidDeviceInformationError:nil]);
+        }
+        return;
+    }
     
     NSMutableDictionary *requestParameters = [NSMutableDictionary dictionary];
     
     if(notificationID)
-        requestParameters[@"notification_id"] = notificationID;
+        requestParameters[@"localized_notification_id"] = notificationID;
+    if (self.currentDevice.user) {
+        [requestParameters addEntriesFromDictionary:@{@"user":@{@"alias":self.currentDevice.user}}];
+    }
+    requestParameters[@"device_token_id"] = self.currentDevice.tokenId;
     
-    [self.requestManager markNotificationAsOpenedWithParams:requestParameters
-                                          completionHandler:nil];
+    __weak typeof(self) weakSelf = self;
+    [self.requestManager markNotificationAsOpenedWithParams:requestParameters completionHandler:^(BOOL success, NSError * _Nullable error) {
+        if (handler) {
+            handler(weakSelf.currentDevice, error);
+        }
+    }];
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(nonnull NSData *)deviceToken
@@ -459,7 +488,7 @@ NSString * const FWTNotifiableNotificationDeviceToken = @"FWTNotifiableNotificat
     
     if (self.currentDevice == nil) {
         if (handler) {
-            handler(@[], [NSError fwt_invalidDeviceInformationError:nil]);
+            handler(@[], [NSError fwt_invalidNotificationError:nil]);
         }
         return;
     }

--- a/Notifiable-iOS/Network/FWTRequesterManager.h
+++ b/Notifiable-iOS/Network/FWTRequesterManager.h
@@ -45,8 +45,10 @@ typedef void (^FWTDeviceListResponse)(NSArray<FWTNotifiableDevice *> *devices, N
    deviceInformation:(NSDictionary * _Nullable)deviceInformation
    completionHandler:(_Nullable FWTDeviceTokenIdResponse)handler;
 
-- (void)markNotificationAsOpenedWithParams:(NSDictionary *)params
-                         completionHandler:(_Nullable FWTSimpleRequestResponse)handler;
+- (void)markNotificationAsOpened:(NSNumber *)notificationId
+                         forUser:(NSString * _Nullable)userAlias
+                andDeviceTokenId:(NSNumber *)deviceTokenId
+           withCompletionHandler:(_Nullable FWTSimpleRequestResponse)handler;
 
 - (void)unregisterTokenId:(NSNumber *)tokenId
                 userAlias:(NSString * _Nullable)userAlias

--- a/Notifiable-iOS/Network/FWTRequesterManager.m
+++ b/Notifiable-iOS/Network/FWTRequesterManager.m
@@ -367,15 +367,7 @@ NSString * const FWTNotifiableProvider          = @"apns";
     
     __weak typeof(self) weakSelf = self;
     [self.requester markNotificationAsOpenedWithParams:params success:^(NSDictionary * _Nullable response) {
-        __strong typeof(weakSelf) sself = weakSelf;
-        if (response == nil) {
-            [sself _markNotificationAsOpenedWithParams:params
-                                              attempts:(attempts - 1)
-                                         previousError:error
-                                     completionHandler:handler];
-            return;
-        }
-        [sself.logger logMessage:@"Notification flagged as opened"];
+        [weakSelf.logger logMessage:@"Notification flagged as opened"];
         if (handler) {
             handler(YES,nil);
         }

--- a/Notifiable-iOS/Network/FWTRequesterManager.m
+++ b/Notifiable-iOS/Network/FWTRequesterManager.m
@@ -95,12 +95,22 @@ NSString * const FWTNotifiableProvider          = @"apns";
          completionHandler:handler];
 }
 
-- (void)markNotificationAsOpenedWithParams:(NSDictionary *)params
-                         completionHandler:(FWTSimpleRequestResponse)handler
+- (void)markNotificationAsOpened:(NSNumber *)notificationId
+                         forUser:(NSString * _Nullable)userAlias
+                andDeviceTokenId:(NSNumber *)deviceTokenId
+           withCompletionHandler:(_Nullable FWTSimpleRequestResponse)handler
 {
-    [self _markNotificationAsOpenedWithParams:params
+    NSMutableDictionary *requestParameters = [NSMutableDictionary dictionary];
+    [requestParameters setObject:notificationId forKey:@"localized_notification_id"];
+    [requestParameters setObject:deviceTokenId forKey:@"device_token_id"];
+    if (userAlias) {
+        [requestParameters addEntriesFromDictionary:@{@"user":@{@"alias":userAlias}}];
+    }
+    
+    [self _markNotificationAsOpenedWithParams:requestParameters
                                      attempts:self.retryAttempts
-                                previousError:nil completionHandler:handler];
+                                previousError:nil
+                            completionHandler:handler];
 }
 
 - (void)listDevicesOfUser:(NSString *)userAlias


### PR DESCRIPTION
The `PUT` request to the endpoint `/user_api/v1/notification_statuses/opened` was missing the parameters `user[alias]`, `device_token_id` and `localized_notification_id`