### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Registering existing token for different user will result in token being reassig
 
 ### Project integration
 
-The `FWTNotifiable` for iOS is avaliable on [Cocoapods](http://cocoapods.org/). To install using it, just add the line to your `Podfile`:
+The `FWTNotifiable` for iOS is avaliable on [CocoaPods](http://cocoapods.org/). To install using it, just add the line to your `Podfile`:
 
 ```
 pod 'FWTNotifiable'
 ```
 
-If you are not using Cocoapods, you can clone this project and import the files into your own project. This libraries uses [AFNetworking](https://github.com/AFNetworking/AFNetworking) as a dependency and is configured as a [submodule](https://git-scm.com/docs/git-submodule).
+If you are not using CocoaPods, you can clone this project and import the files into your own project. This libraries uses [AFNetworking](https://github.com/AFNetworking/AFNetworking) as a dependency and is configured as a [submodule](https://git-scm.com/docs/git-submodule).
 
 You can see an example of the implementation in the [Sample folder](Sample).
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
