### PR TITLE
Change Notification center notifications

### DIFF
--- a/Notifiable-iOS.podspec
+++ b/Notifiable-iOS.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 
   s.name         = "Notifiable-iOS"
-  s.version      = "0.1.0"
+  s.version      = "0.1.1"
   s.platform     = :ios, '8.0'
   s.summary      = "Utility classes to integrate with Notifiable-Rails gem"
 

--- a/Notifiable-iOS.podspec
+++ b/Notifiable-iOS.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 
   s.name         = "Notifiable-iOS"
-  s.version      = "0.1.1"
+  s.version      = "0.1.2"
   s.platform     = :ios, '8.0'
   s.summary      = "Utility classes to integrate with Notifiable-Rails gem"
 

--- a/Sample/Podfile.lock
+++ b/Sample/Podfile.lock
@@ -1,8 +1,22 @@
 PODS:
-  - AFNetworking (1.3.4)
+  - AFNetworking (3.0.4):
+    - AFNetworking/NSURLSession (= 3.0.4)
+    - AFNetworking/Reachability (= 3.0.4)
+    - AFNetworking/Security (= 3.0.4)
+    - AFNetworking/Serialization (= 3.0.4)
+    - AFNetworking/UIKit (= 3.0.4)
+  - AFNetworking/NSURLSession (3.0.4):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (3.0.4)
+  - AFNetworking/Security (3.0.4)
+  - AFNetworking/Serialization (3.0.4)
+  - AFNetworking/UIKit (3.0.4):
+    - AFNetworking/NSURLSession
   - Keys (1.0.0)
-  - Notifiable-iOS (0.1.0):
-    - AFNetworking (~> 1.3.0)
+  - Notifiable-iOS (0.1.1):
+    - AFNetworking (~> 3.0.4)
   - SVProgressHUD (1.1.3)
 
 DEPENDENCIES:
@@ -17,9 +31,9 @@ EXTERNAL SOURCES:
     :path: ".."
 
 SPEC CHECKSUMS:
-  AFNetworking: cf8e418e16f0c9c7e5c3150d019a3c679d015018
+  AFNetworking: a0075feb321559dc78d9d85b55d11caa19eabb93
   Keys: 7d2ff6ff42f6903358267ce56e9392f83c31acfe
-  Notifiable-iOS: b205bdbdf813a19af4226eab7732bf6dd3c95669
+  Notifiable-iOS: 5626e60216d4a5ac01351551617106d7364fe269
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
 
 COCOAPODS: 0.39.0

--- a/Sample/Sample/AppDelegate.swift
+++ b/Sample/Sample/AppDelegate.swift
@@ -14,14 +14,12 @@ import FWTNotifiable
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    var notifiableManager:FWTNotifiableManager!
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         
         let keys = SampleKeys()
-        self.notifiableManager = FWTNotifiableManager(url: "http://fw-notifiable-staging2.herokuapp.com/", accessId: keys.fWTAccessID(), andSecretKey: keys.fWTSecretKey())
         
-        self.getMainViewController()?.manager = self.notifiableManager
+        self.getMainViewController()?.manager = FWTNotifiableManager(url: "http://fw-notifiable-staging2.herokuapp.com/", accessId: keys.fWTAccessID(), andSecretKey: keys.fWTSecretKey())
         
         if let remoteNotification = launchOptions?[UIApplicationLaunchOptionsRemoteNotificationKey] as? [NSObject:AnyObject] {
             self.application(application, didReceiveRemoteNotification: remoteNotification)
@@ -44,7 +42,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject]) {
-        self.notifiableManager.applicationDidReceiveRemoteNotification(userInfo);
+        if (FWTNotifiableManager.applicationDidReceiveRemoteNotification(userInfo)) {
+            print("Notifiable server notification")
+        }
     }
     
     func application(application: UIApplication, didRegisterUserNotificationSettings notificationSettings: UIUserNotificationSettings) {
@@ -52,6 +52,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: NSData) {
-        self.notifiableManager.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+        FWTNotifiableManager.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
     }
 }

--- a/Sample/Sample/ViewController.swift
+++ b/Sample/Sample/ViewController.swift
@@ -116,7 +116,7 @@ extension ViewController {
     private func _registerForNotifications(completion:FWTRegisterCompleted) {
         self.registerCompleted = completion
         SVProgressHUD.show()
-        let notificationSettings = UIUserNotificationSettings(forTypes: .Badge, categories: nil)
+        let notificationSettings = UIUserNotificationSettings(forTypes: [.Alert, .Badge, .Sound], categories: nil)
         UIApplication.sharedApplication().registerUserNotificationSettings(notificationSettings)
     }
 }


### PR DESCRIPTION
Change the way that the FWTNotifiableManager handles device remote notifications registration to stop using the notification center to notify other objects