### PR TITLE
Update manager method signatures

### DIFF
--- a/Notifiable-iOS/FWTNotifiableManager.h
+++ b/Notifiable-iOS/FWTNotifiableManager.h
@@ -18,14 +18,13 @@ extern NSString * const FWTNotifiableNotificationDeviceToken;
 @protocol FWTNotifiableLogger;
 
 @class FWTNotifiableDevice;
+@class FWTNotifiableManager;
 
 typedef void (^FWTNotifiableOperationCompletionHandler)(FWTNotifiableDevice * _Nullable device, NSError * _Nullable error);
 typedef void (^FWTNotifiableListOperationCompletionHandler)(NSArray<FWTNotifiableDevice*> * _Nullable devices, NSError * _Nullable error);
 
-typedef void (^FWTNotifiableDidRegisterBlock)(NSData * token);
-typedef void (^FWTNotifiableDidReceiveNotificationBlock)(FWTNotifiableDevice * device, NSDictionary *notification);
-
-@class FWTNotifiableManager;
+typedef void (^FWTNotifiableDidRegisterBlock)(FWTNotifiableManager *manager, NSData * token);
+typedef void (^FWTNotifiableDidReceiveNotificationBlock)(FWTNotifiableManager *manager, FWTNotifiableDevice * device, NSDictionary *notification);
 
 @protocol FWTNotifiableManagerListener <NSObject>
 
@@ -125,158 +124,23 @@ typedef void (^FWTNotifiableDidReceiveNotificationBlock)(FWTNotifiableDevice * d
        andNotificationBlock:(_Nullable FWTNotifiableDidReceiveNotificationBlock)notificationBlock  NS_DESIGNATED_INITIALIZER;
 
 #pragma mark - Register Anonymous device
-/**
- Register a device without a user associated to it. If the token already exists in the server,
- the device configuration in the server will not change, otherwise, a new device will be created.
- 
- @warning If the application:didRegisterForRemoteNotificationsWithDeviceToken: wasn't called,
- this operation will not have a token to register.
- 
- @param handler Block called once that the operation is finished.
- */
-- (void)registerAnonymousDeviceWithCompletionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
-
-/**
- Register a device without a user associated to it. If the token already exists in the server,
- the device configuration in the server will not change, otherwise, a new device will be created.
- 
- @param token   The device token.
- @param handler Block called once that the operation is finished.
-*/
-- (void)registerAnonymousToken:(NSData *)token
-             completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
-
-/**
- Register a device without a user associated to it. If the token already exists in the server,
- the device configuration in the server will not change, otherwise, a new device will be created.
- 
- @param token       The device token.
- @param deviceName  A label for the device.
- @param handler     Block called once that the operation is finished.
- */
-- (void)registerAnonymousToken:(NSData *)token
-                    deviceName:(NSString *)deviceName
-             completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
-
-/**
- Register a device, without a user associated to it. If the token already exists in the server,
- the device locale will be updated. Otherwise, a new device will be created with the token 
- and locale provided.
- 
- @param token   The device token.
- @param locale  The locale of the device.
- @param handler Block called once that the operation is finished.
-*/
-- (void)registerAnonymousToken:(NSData *)token
-                    withLocale:(NSLocale *)locale
-             completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
-
-/**
- Register a device, without a user associated to it. If the token already exists in the server,
- the device locale will be updated. Otherwise, a new device will be created with the token
- and locale provided.
- 
- @param token               The device token.
- @param locale              The locale of the device.
- @param deviceInformation   Aditional information about the device.
- @param handler             Block called once that the operation is finished.
-*/
-- (void)registerAnonymousToken:(NSData *)token
-                    withLocale:(NSLocale *)locale
-             deviceInformation:(NSDictionary *)deviceInformation
-             completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
 
 /**
  Register a device, without a user associated to it, but with a name to represent the device.
  If the token already exists in the server, the device locale will be updated. 
  Otherwise, a new device will be created with the token and locale provided.
  
- @param token               The device token.
- @param deviceName          A label for the device.
+ @param name                A label for the device.
  @param locale              The locale of the device.
  @param deviceInformation   Aditional information about the device.
  @param handler             Block called once that the operation is finished.
  */
--(void)registerAnonymousToken:(NSData *)token
-                   deviceName:(NSString * _Nullable)deviceName
-                   withLocale:(NSLocale *)locale
-            deviceInformation:(NSDictionary *)deviceInformation
-            completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
+-(void)registerAnonymousDeviceWithName:(NSString * _Nullable)name
+                                locale:(NSLocale * _Nullable)locale
+                     deviceInformation:(NSDictionary * _Nullable)deviceInformation
+                  andCompletionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
 
 #pragma mark - Register device to a specific user
-/**
- Register a device with a user associated to it. If the token already exists in the server,
- the device configuration in the server will not change, otherwise, a new device will be created.
- If the user alias doesn't exist, a new user will be created.
- 
- @warning If the application:didRegisterForRemoteNotificationsWithDeviceToken: wasn't called,
- this operation will not have a token to register.
- 
- @param userAlias   The alias of the user in the server.
- @param handler     Block called once that the operation is finished.
- */
-- (void)registerDeviceWithUserAlias:(NSString *)userAlias
-                  completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
-
-/**
- Register a device with a user associated to it. If the token already exists in the server,
- the device configuration in the server will not change, otherwise, a new device will be created.
- If the user alias doesn't exist, a new user will be created.
- 
- @param token       The device token.
- @param userAlias   The alias of the user in the server.
- @param handler     Block called once that the operation is finished.
-*/
-- (void)registerToken:(NSData *)token
-        withUserAlias:(NSString *)userAlias
-    completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
-
-/**
- Register a device with a user associated to it. If the token already exists in the server,
- the device configuration in the server will not change, otherwise, a new device will be created.
- If the user alias doesn't exist, a new user will be created.
- 
- @param token       The device token.
- @param userAlias   The alias of the user in the server.
- @param deviceName  A label for the device.
- @param handler     Block called once that the operation is finished.
- */
-- (void)registerToken:(NSData *)token
-        withUserAlias:(NSString *)userAlias
-           deviceName:(NSString *)deviceName
-    completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
-
-/**
- Register a device, with a user associated to it. If the token already exists in the server,
- the device locale will be updated. Otherwise, a new device will be created with the token
- and locale provided. If the user alias doesn't exist, a new user will be created.
- 
- @param token       The device token.
- @param locale      The locale of the device.
- @param userAlias   The alias of the user in the server.
- @param handler     Block called once that the operation is finished.
-*/
-- (void)registerToken:(NSData *)token
-        withUserAlias:(NSString *)userAlias
-            andLocale:(NSLocale *)locale
-    completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
-
-/**
- Register a device, with a user associated to it. If the token already exists in the server,
- the device locale will be updated. Otherwise, a new device will be created with the token
- and locale provided. If the user alias doesn't exist, a new user will be created.
- 
- @param token       The device token.
- @param locale      The locale of the device.
- @param userAlias   The alias of the user in the server.
- @param deviceInformation   Aditional information about the device
- @param handler     Block called once that the operation is finished.
-*/
-- (void)registerToken:(NSData *)token
-        withUserAlias:(NSString *)userAlias
-               locale:(NSLocale *)locale
-    deviceInformation:(NSDictionary *)deviceInformation
-    completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
 
 /**
  Register a device, with a user associated to it, but with a name to represent the device. 
@@ -284,19 +148,17 @@ typedef void (^FWTNotifiableDidReceiveNotificationBlock)(FWTNotifiableDevice * d
  Otherwise, a new device will be created with the token and locale provided. 
  If the user alias doesn't exist, a new user will be created.
  
- @param token       The device token.
  @param deviceName  A label for the device.
  @param locale      The locale of the device.
  @param userAlias   The alias of the user in the server.
  @param deviceInformation   Aditional information about the device
  @param handler     Block called once that the operation is finished.
  */
-- (void)registerToken:(NSData *)token
-           deviceName:(NSString * _Nullable)deviceName
-        withUserAlias:(NSString *)userAlias
-               locale:(NSLocale *)locale
-    deviceInformation:(NSDictionary *)deviceInformation
-    completionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
+- (void)registerDeviceWithName:(NSString * _Nullable)deviceName
+                     userAlias:(NSString *)userAlias
+                        locale:(NSLocale * _Nullable)locale
+             deviceInformation:(NSDictionary * _Nullable)deviceInformation
+          andCompletionHandler:(_Nullable FWTNotifiableOperationCompletionHandler)handler;
 
 #pragma mark - Update device information
 /**

--- a/Notifiable-iOSUnitTests/FWTRegisterTests.m
+++ b/Notifiable-iOSUnitTests/FWTRegisterTests.m
@@ -59,130 +59,71 @@
 }
 
 - (void)testRegisterAnonymousToken {
+    
+    NSData* token = [@"token" dataUsingEncoding:NSUTF8StringEncoding];
+    [FWTNotifiableManager application:OCMOCK_ANY didRegisterForRemoteNotificationsWithDeviceToken:token];
     FWTNotifiableManager *manager = [[FWTNotifiableManager alloc] initWithURL:OCMOCK_ANY
                                                                      accessId:OCMOCK_ANY
                                                                     secretKey:OCMOCK_ANY
                                                              didRegisterBlock:nil
                                                          andNotificationBlock:nil];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    XCTAssertThrows([manager registerAnonymousToken:nil completionHandler:nil], @"The register should fail if no token is provided");
-#pragma clang diagnostic pop
-    
-    [self _expectAnonymousRegisterOnManager:manager withBlock:^{
-        [manager registerAnonymousToken:OCMOCK_ANY
-                      completionHandler:nil];
-    }];
-    
-    [self _expectAnonymousRegisterOnManager:manager withBlock:^{
-        [manager registerAnonymousToken:OCMOCK_ANY
-                             deviceName:OCMOCK_ANY
-                      completionHandler:nil];
-    }];
-    
-    [self _expectAnonymousRegisterOnManager:manager withBlock:^{
-        [manager registerAnonymousToken:OCMOCK_ANY
-                             withLocale:OCMOCK_ANY
-                      completionHandler:nil];
-    }];
-    
-    [self _expectAnonymousRegisterOnManager:manager withBlock:^{
-        [manager registerAnonymousToken:OCMOCK_ANY
-                             withLocale:OCMOCK_ANY
-                      deviceInformation:OCMOCK_ANY
-                      completionHandler:nil];
-    }];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Device information"];
     NSLocale* locale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
-    NSData* token = [@"token" dataUsingEncoding:NSUTF8StringEncoding];
     NSString *deviceName = @"deviceName";
     
     [self stubDeviceRegisterResponse:@42 andError:nil onMock:self.requesterManagerMock withBlock:^{
-        [manager registerAnonymousToken:token
-                             deviceName:deviceName
-                             withLocale:locale
-                      deviceInformation:@{@"test":@YES}
-                      completionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
-                          
-                          XCTAssertNotNil(device);
-                          
-                          FWTNotifiableDevice *currentDevice = manager.currentDevice;
-                          XCTAssertTrue([currentDevice.tokenId integerValue] == 42);
-                          XCTAssertTrue([[currentDevice.token fwt_notificationTokenString] isEqualToString:[token fwt_notificationTokenString]]);
-                          XCTAssertTrue([currentDevice.name isEqualToString:deviceName]);
-                          XCTAssertTrue([currentDevice.locale.localeIdentifier isEqualToString:locale.localeIdentifier]);
-                          XCTAssertTrue([currentDevice.information[@"test"] boolValue]);
-                          [expectation fulfill];
-                      }];
+        [manager registerAnonymousDeviceWithName:deviceName
+                                          locale:locale
+                               deviceInformation:@{@"test":@YES}
+                            andCompletionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
+                                
+                                XCTAssertNotNil(device);
+                              
+                                FWTNotifiableDevice *currentDevice = manager.currentDevice;
+                                XCTAssertEqualObjects(currentDevice, device);
+                                XCTAssertTrue([currentDevice.tokenId integerValue] == 42);
+                                XCTAssertTrue([[currentDevice.token fwt_notificationTokenString] isEqualToString:[token fwt_notificationTokenString]]);
+                                XCTAssertTrue([currentDevice.name isEqualToString:deviceName]);
+                                XCTAssertTrue([currentDevice.locale.localeIdentifier isEqualToString:locale.localeIdentifier]);
+                                XCTAssertTrue([currentDevice.information[@"test"] boolValue]);
+                                [expectation fulfill];
+                            }];
     }];
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testRegisterTokenToUser {
+    NSData* token = [@"token" dataUsingEncoding:NSUTF8StringEncoding];
     FWTNotifiableManager *manager = [[FWTNotifiableManager alloc] initWithURL:OCMOCK_ANY
                                                                      accessId:OCMOCK_ANY
                                                                     secretKey:OCMOCK_ANY
                                                              didRegisterBlock:nil
                                                          andNotificationBlock:nil];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    XCTAssertThrows([manager registerToken:OCMOCK_ANY withUserAlias:nil completionHandler:nil], @"The register should fail if no user is provided");
-    XCTAssertThrows([manager registerToken:nil withUserAlias:OCMOCK_ANY completionHandler:nil], @"The register should fail if no token is provided");
-    XCTAssertThrows([manager registerToken:OCMOCK_ANY withUserAlias:OCMOCK_ANY completionHandler:nil], @"The register should fail if an empty user string is provided");
-#pragma clang diagnostic pop
-    
-    NSString *userAlias = @"test";
-    
-    [self _expectUserAliasRegisterOnManager:manager withBlock:^{
-        [manager registerToken:OCMOCK_ANY
-                 withUserAlias:userAlias
-             completionHandler:nil];
-    }];
-    
-    [self _expectUserAliasRegisterOnManager:manager withBlock:^{
-        [manager registerToken:OCMOCK_ANY
-                 withUserAlias:userAlias
-                     andLocale:OCMOCK_ANY
-             completionHandler:nil];
-    }];
-    
-    [self _expectUserAliasRegisterOnManager:manager withBlock:^{
-        [manager registerToken:OCMOCK_ANY
-                 withUserAlias:userAlias
-                    deviceName:OCMOCK_ANY
-             completionHandler:nil];
-    }];
-    
-    [self _expectUserAliasRegisterOnManager:manager withBlock:^{
-        [manager registerToken:OCMOCK_ANY
-                 withUserAlias:userAlias
-                        locale:OCMOCK_ANY
-             deviceInformation:OCMOCK_ANY
-             completionHandler:nil];
-    }];
+    [FWTNotifiableManager application:OCMOCK_ANY didRegisterForRemoteNotificationsWithDeviceToken:token];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Register device with user"];
     NSLocale* locale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
-    NSData* token = [@"token" dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *userAlias = @"test";
     NSString *deviceName = @"deviceName";
     
     [self stubDeviceRegisterResponse:@42 andError:nil onMock:self.requesterManagerMock withBlock:^{
-        [manager registerToken:token
-                    deviceName:deviceName
-                 withUserAlias:userAlias
-                        locale:locale
-             deviceInformation:@{@"test":@YES}
-             completionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
-                 XCTAssertTrue([device.tokenId integerValue] == 42);
-                 XCTAssertTrue([[device.token fwt_notificationTokenString] isEqualToString:[token fwt_notificationTokenString]]);
-                 XCTAssertTrue([device.user isEqualToString:userAlias]);
-                 XCTAssertTrue([device.name isEqualToString:deviceName]);
-                 XCTAssertTrue([device.locale.localeIdentifier isEqualToString:locale.localeIdentifier]);
-                 XCTAssertTrue([device.information[@"test"] boolValue]);
+        [manager registerDeviceWithName:deviceName
+                              userAlias:userAlias
+                                 locale:locale
+                      deviceInformation:@{@"test":@YES}
+                   andCompletionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
+                       FWTNotifiableDevice *currentDevice = manager.currentDevice;
+                       XCTAssertEqualObjects(currentDevice, device);
+                       XCTAssertTrue([device.tokenId integerValue] == 42);
+                       XCTAssertTrue([[device.token fwt_notificationTokenString] isEqualToString:[token fwt_notificationTokenString]]);
+                       XCTAssertTrue([device.user isEqualToString:userAlias]);
+                       XCTAssertTrue([device.name isEqualToString:deviceName]);
+                       XCTAssertTrue([device.locale.localeIdentifier isEqualToString:locale.localeIdentifier]);
+                       XCTAssertTrue([device.information[@"test"] boolValue]);
                  
-                 [expectation fulfill];
-             }];
+                       [expectation fulfill];
+                   }];
     }];
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
@@ -190,6 +131,7 @@
 
 - (void) testFailOnRegisterAnonymousDevice
 {
+    [FWTNotifiableManager application:OCMOCK_ANY didRegisterForRemoteNotificationsWithDeviceToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding]];
     FWTNotifiableManager *manager = [[FWTNotifiableManager alloc] initWithURL:OCMOCK_ANY
                                                                      accessId:OCMOCK_ANY
                                                                     secretKey:OCMOCK_ANY
@@ -197,17 +139,16 @@
                                                          andNotificationBlock:nil];
     XCTestExpectation *expectation = [self expectationWithDescription:@"Fail unregister"];
     [self stubDeviceRegisterResponse:nil andError:[NSError errorWithDomain:@"domain" code:404 userInfo:nil] onMock:self.requesterManagerMock withBlock:^{
-        [manager registerAnonymousToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding]
-                             deviceName:@"name"
-                             withLocale:[NSLocale localeWithLocaleIdentifier:@"pt_BR"]
-                      deviceInformation:@{@"test":@YES}
-                      completionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
+        [manager registerAnonymousDeviceWithName:@"name"
+                                          locale:[NSLocale localeWithLocaleIdentifier:@"pt_BR"]
+                               deviceInformation:@{@"test":@YES}
+                            andCompletionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
                           
-                          XCTAssertNil(device);
-                          XCTAssertNotNil(error);
+                                XCTAssertNil(device);
+                                XCTAssertNotNil(error);
                           
-                          [expectation fulfill];
-                      }];
+                                [expectation fulfill];
+                            }];
     }];
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
@@ -221,74 +162,22 @@
                                                                     secretKey:OCMOCK_ANY
                                                              didRegisterBlock:nil
                                                          andNotificationBlock:nil];
+    [FWTNotifiableManager application:OCMOCK_ANY didRegisterForRemoteNotificationsWithDeviceToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding]];
     XCTestExpectation *expectation = [self expectationWithDescription:@"Fail unregister"];
     [self stubDeviceRegisterResponse:nil andError:[NSError errorWithDomain:@"domain" code:404 userInfo:nil] onMock:self.requesterManagerMock withBlock:^{
-        [manager registerToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding]
-                    deviceName:@"name"
-                 withUserAlias:@"user"
-                        locale:[NSLocale localeWithLocaleIdentifier:@"pt_BR"]
-             deviceInformation:@{@"test":@YES}
-             completionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
-                          
+        [manager registerDeviceWithName:@"name"
+                              userAlias:@"user"
+                                 locale:[NSLocale localeWithLocaleIdentifier:@"pt_BR"]
+                      deviceInformation:@{@"test":@YES}
+                   andCompletionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
                           XCTAssertNil(device);
                           XCTAssertNotNil(error);
-                          
                           [expectation fulfill];
              }];
     }];
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
     XCTAssertNil(manager.currentDevice);
-}
-
-- (void) _expectUserAliasRegisterOnManager:(FWTNotifiableManager *)manager withBlock:(void(^)(void))block
-{
-    id managerMock = [self _userAliasMockWithManager:manager];
-    
-    [self _expectRegisterWithBlock:^{
-        block();
-    }];
-    
-    if(managerMock) {
-        OCMVerifyAll(managerMock);
-    }
-    [managerMock stopMocking];
-}
-
-- (void) _expectAnonymousRegisterOnManager:(FWTNotifiableManager *)manager withBlock:(void(^)(void))block
-{
-    id managerMock = [self _anonymousMockWithManager:manager];
-
-    [self _expectRegisterWithBlock:^{
-        block();
-    }];
-    
-    if(managerMock) {
-        OCMVerifyAll(managerMock);
-    }
-    [managerMock stopMocking];
-}
-
-- (id) _userAliasMockWithManager:(FWTNotifiableManager *)manager
-{
-    id managerMock = OCMPartialMock(manager);
-    OCMExpect([managerMock registerToken:OCMOCK_ANY deviceName:OCMOCK_ANY withUserAlias:OCMOCK_ANY locale:OCMOCK_ANY deviceInformation:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andForwardToRealObject();
-    return managerMock;
-}
-
-- (id) _anonymousMockWithManager:(FWTNotifiableManager *)manager
-{
-    id managerMock = OCMPartialMock(manager);
-    OCMExpect([managerMock registerAnonymousToken:OCMOCK_ANY deviceName:OCMOCK_ANY withLocale:OCMOCK_ANY deviceInformation:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andForwardToRealObject();
-    
-    return managerMock;
-}
-
-- (void) _expectRegisterWithBlock:(void(^)(void))block
-{
-    OCMExpect([self.requesterManagerMock registerDeviceWithUserAlias:[OCMArg any] token:[OCMArg any] name:[OCMArg any] locale:[OCMArg any] deviceInformation:[OCMArg any] completionHandler:[OCMArg any]]);
-    block();
-    OCMVerifyAll(self.requesterManagerMock);
 }
 
 @end

--- a/Notifiable-iOSUnitTests/FWTTestCase.h
+++ b/Notifiable-iOSUnitTests/FWTTestCase.h
@@ -19,7 +19,7 @@
 
 - (void) stubDeviceUpdateResponse:(NSNumber *)deviceTokenId onMock:(id)mock;
 
-- (void) registerAnonymousDeviceWithToken:(NSData *)token tokenId:(NSNumber *)tokenId andError:(NSError *)error onManager:(FWTNotifiableManager *)manager andRquesterMock:(id)mock;
-- (void) registerDeviceWithToken:(NSData *)token tokenId:(NSNumber *)tokenId error:(NSError *)error andUserAlias:(NSString *)userAlias onManager:(FWTNotifiableManager *)manager andRquesterMock:(id)mock;
+- (void) registerAnonymousDeviceWithTokenId:(NSNumber *)tokenId andError:(NSError *)error onManager:(FWTNotifiableManager *)manager andRquesterMock:(id)mock;
+- (void) registerDeviceWithTokenId:(NSNumber *)tokenId error:(NSError *)error andUserAlias:(NSString *)userAlias onManager:(FWTNotifiableManager *)manager andRquesterMock:(id)mock;
 
 @end

--- a/Notifiable-iOSUnitTests/FWTTestCase.m
+++ b/Notifiable-iOSUnitTests/FWTTestCase.m
@@ -90,19 +90,19 @@ typedef void(^FWTTestRegisterBlock)(FWTNotifiableDevice *device, NSError* error)
              completionHandler:OCMOCK_ANY]).andDo(postProxyBlock);
 }
 
-- (void) registerAnonymousDeviceWithToken:(NSData *)token tokenId:(NSNumber *)tokenId andError:(NSError *)error onManager:(FWTNotifiableManager *)manager andRquesterMock:(id)mock
+- (void) registerAnonymousDeviceWithTokenId:(NSNumber *)tokenId andError:(NSError *)error onManager:(FWTNotifiableManager *)manager andRquesterMock:(id)mock
 {
     [self _registerDeviceWithTokenId:tokenId andError:error onMock:mock andBlock:^(FWTTestRegisterBlock registerBlock) {
-        [manager registerAnonymousToken:token completionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
+        [manager registerAnonymousDeviceWithName:nil locale:nil deviceInformation:nil andCompletionHandler:^(FWTNotifiableDevice * _Nullable device, NSError * _Nullable error) {
             registerBlock(device, error);
         }];
     }];
 }
 
-- (void) registerDeviceWithToken:(NSData *)token tokenId:(NSNumber *)tokenId error:(NSError *)error andUserAlias:(NSString *)userAlias onManager:(FWTNotifiableManager *)manager andRquesterMock:(id)mock
+- (void) registerDeviceWithTokenId:(NSNumber *)tokenId error:(NSError *)error andUserAlias:(NSString *)userAlias onManager:(FWTNotifiableManager *)manager andRquesterMock:(id)mock
 {
     [self _registerDeviceWithTokenId:tokenId andError:error onMock:mock andBlock:^(FWTTestRegisterBlock registerBlock) {
-        [manager registerToken:token withUserAlias:userAlias completionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
+        [manager registerDeviceWithName:nil userAlias:userAlias locale:nil deviceInformation:nil andCompletionHandler:^(FWTNotifiableDevice * _Nullable device, NSError * _Nullable error) {
             registerBlock(device, error);
         }];
     }];

--- a/Notifiable-iOSUnitTests/FWTUnregisterTests.m
+++ b/Notifiable-iOSUnitTests/FWTUnregisterTests.m
@@ -18,6 +18,7 @@
 @property (nonatomic, strong) id requesterManagerMock;
 @property (nonatomic, strong) id httpRequestMock;
 @property (nonatomic, strong) FWTNotifiableManager *manager;
+@property (nonatomic, strong) NSData *deviceToken;
 
 @end
 
@@ -26,6 +27,7 @@
 - (FWTNotifiableManager *)manager
 {
     if (self->_manager == nil) {
+        [FWTNotifiableManager application:OCMOCK_ANY didRegisterForRemoteNotificationsWithDeviceToken:self.deviceToken];
         self->_manager = [[FWTNotifiableManager alloc] initWithURL:OCMOCK_ANY
                                                           accessId:OCMOCK_ANY
                                                          secretKey:OCMOCK_ANY
@@ -33,6 +35,14 @@
                                               andNotificationBlock:nil];
     }
     return self->_manager;
+}
+
+- (NSData *)deviceToken
+{
+    if (self->_deviceToken == nil) {
+        self->_deviceToken = [@"test" dataUsingEncoding:NSUTF8StringEncoding];
+    }
+    return self->_deviceToken;
 }
 
 - (void)mockRequester
@@ -83,8 +93,7 @@
 
 - (void) testUnregisterDevice
 {
-    [self registerAnonymousDeviceWithToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding]
-                                   tokenId:@42
+    [self registerAnonymousDeviceWithTokenId:@42
                                   andError:nil
                                  onManager:self.manager
                            andRquesterMock:self.requesterManagerMock];
@@ -106,8 +115,7 @@
 
 - (void) testErrorOnUnregister
 {
-    [self registerAnonymousDeviceWithToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding]
-                                   tokenId:@42
+    [self registerAnonymousDeviceWithTokenId:@42
                                   andError:nil
                                  onManager:self.manager
                            andRquesterMock:self.requesterManagerMock];

--- a/Notifiable-iOSUnitTests/FWTUserOperationTests.m
+++ b/Notifiable-iOSUnitTests/FWTUserOperationTests.m
@@ -19,6 +19,7 @@
 @property (nonatomic, strong) id httpRequestMock;
 @property (nonatomic, strong) FWTNotifiableManager *manager;
 @property (nonatomic, strong) NSNumber *deviceTokenId;
+@property (nonatomic, strong) NSData *deviceToken;
 
 @end
 
@@ -35,6 +36,7 @@
 - (FWTNotifiableManager *)manager
 {
     if (self->_manager == nil) {
+        [FWTNotifiableManager application:OCMOCK_ANY didRegisterForRemoteNotificationsWithDeviceToken:self.deviceToken];
         self->_manager = [[FWTNotifiableManager alloc] initWithURL:OCMOCK_ANY
                                                           accessId:OCMOCK_ANY
                                                          secretKey:OCMOCK_ANY
@@ -42,6 +44,14 @@
                                               andNotificationBlock:nil];
     }
     return self->_manager;
+}
+
+- (NSData *)deviceToken
+{
+    if (self->_deviceToken == nil) {
+        self->_deviceToken = [@"test" dataUsingEncoding:NSUTF8StringEncoding];
+    }
+    return self->_deviceToken;
 }
 
 - (void)mockRequester
@@ -81,7 +91,7 @@
 
 - (void)testAssociateUserWithAnonymous {
     [self stubDeviceUpdateResponse:self.deviceTokenId onMock:self.requesterManagerMock];
-    [self registerAnonymousDeviceWithToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding] tokenId:self.deviceTokenId andError:nil onManager:self.manager andRquesterMock:self.requesterManagerMock];
+    [self registerAnonymousDeviceWithTokenId:self.deviceTokenId andError:nil onManager:self.manager andRquesterMock:self.requesterManagerMock];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"associate"];
     [self.manager associateDeviceToUser:@"user" completionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
@@ -95,7 +105,7 @@
 
 - (void)testAssociateUserWithPreviousUser {
     [self stubDeviceUpdateResponse:self.deviceTokenId onMock:self.requesterManagerMock];
-    [self registerDeviceWithToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding] tokenId:self.deviceTokenId error:nil andUserAlias:@"user" onManager:self.manager andRquesterMock:self.requesterManagerMock];
+    [self registerDeviceWithTokenId:self.deviceTokenId error:nil andUserAlias:@"user" onManager:self.manager andRquesterMock:self.requesterManagerMock];
     
     XCTAssertEqualObjects(self.manager.currentDevice.user, @"user");
     
@@ -112,7 +122,7 @@
 
 - (void) testAnonymiseUser {
     [self stubDeviceRegisterResponse:self.deviceTokenId onMock:self.requesterManagerMock];
-    [self registerDeviceWithToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding] tokenId:self.deviceTokenId error:nil andUserAlias:@"user" onManager:self.manager andRquesterMock:self.requesterManagerMock];
+    [self registerDeviceWithTokenId:self.deviceTokenId error:nil andUserAlias:@"user" onManager:self.manager andRquesterMock:self.requesterManagerMock];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"associate"];
     [self.manager anonymiseTokenWithCompletionHandler:^(FWTNotifiableDevice *device, NSError * _Nullable error) {
@@ -126,7 +136,7 @@
 }
 
 - (void) testListDevices {
-    [self registerAnonymousDeviceWithToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding] tokenId:self.deviceTokenId andError:nil onManager:self.manager andRquesterMock:self.requesterManagerMock];
+    [self registerAnonymousDeviceWithTokenId:self.deviceTokenId andError:nil onManager:self.manager andRquesterMock:self.requesterManagerMock];
     [self _stubDeviceList];
     XCTestExpectation *expectation = [self expectationWithDescription:@"associate"];
     [self.manager listDevicesRelatedToUserWithCompletionHandler:^(NSArray<FWTNotifiableDevice *> * _Nullable devices, NSError * _Nullable error) {
@@ -139,7 +149,7 @@
 }
 
 - (void) testListDevicesUser {
-    [self registerDeviceWithToken:[@"test" dataUsingEncoding:NSUTF8StringEncoding] tokenId:self.deviceTokenId error:nil andUserAlias:@"user" onManager:self.manager andRquesterMock:self.requesterManagerMock];
+    [self registerDeviceWithTokenId:self.deviceTokenId error:nil andUserAlias:@"user" onManager:self.manager andRquesterMock:self.requesterManagerMock];
     [self _stubDeviceList];
     XCTestExpectation *expectation = [self expectationWithDescription:@"associate"];
     [self.manager listDevicesRelatedToUserWithCompletionHandler:^(NSArray<FWTNotifiableDevice *> * _Nullable devices, NSError * _Nullable error) {

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ You can see an example of the implementation in the [Sample folder](Sample).
 To use the `FWTNotifiableManager`, create a new object passing your server URL, application access id, application secret key. You can, also, provide blocks that will be used to notify your code when the device is registered for remote notifications and when it receives a new notification.
 
 ```swift
-self.manager = FWTNotifiableManager(url: <<SERVER_URL>>, accessId: <<USER_API_ACCESS_ID>>, secretKey: <<USER_API_SECRET_KEY>>, didRegisterBlock: { [unowned self] (token) -> Void in 
+self.manager = FWTNotifiableManager(url: <<SERVER_URL>>, accessId: <<USER_API_ACCESS_ID>>, secretKey: <<USER_API_SECRET_KEY>>, didRegisterBlock: { [unowned self] (manager, token) -> Void in 
 	...
-}, andNotificationBlock:{ [unowned self] (device, notification) -> Void in
+}, andNotificationBlock:{ [unowned self] (manager, device, notification) -> Void in
 	...
 })
 ```
@@ -93,9 +93,9 @@ override func viewDidLoad() {
     super.viewDidLoad()
     
     //1 - Config manager
-    self.manager = FWTNotifiableManager(URL: serverURL, accessId: accessID, secretKey: secretKey(), didRegisterBlock: { [unowned self] (token) -> Void in
+    self.manager = FWTNotifiableManager(URL: serverURL, accessId: accessID, secretKey: secretKey(), didRegisterBlock: { [unowned self] (manager, token) -> Void in
         //3 - Register device
-        self.registerDevice(token)
+        self.registerDevice(manager, token: token)
     }, andNotificationBlock: nil)
 
     //2 - Request for permission
@@ -103,8 +103,8 @@ override func viewDidLoad() {
     UIApplication.sharedApplication().registerUserNotificationSettings(notificationSettings)
 }
     
-func registerDevice(token:NSData) {
-    self.manager.registerAnonymousToken(token, deviceName: "iPhone", withLocale: NSLocale.autoupdatingCurrentLocale(), deviceInformation: ["onsite":true]) { (device, error) -> Void in
+func registerDevice(manager:FWTNotifiableManager, token:NSData) {
+    manager. registerAnonymousDeviceWithName("iPhone", locale: NSLocale.autoupdatingCurrentLocale(), deviceInformation: ["onsite":true]) { (device, error) -> Void in
     	...
     }
 }
@@ -113,8 +113,8 @@ func registerDevice(token:NSData) {
 Or register a device associated to a user:
 
 ```swift
-func registerDevice(token:NSData) {
-    self.manager.registerToken(token, deviceName: "device", withUserAlias: "user", locale: NSLocale.autoupdatingCurrentLocale(), deviceInformation: ["onsite":true]) { (device, error) -> Void in
+func registerDevice(manager:FWTNotifiableManager, token:NSData) {
+    manager.registerDeviceWithName("device", userAlias: "user", locale: NSLocale.autoupdatingCurrentLocale(), deviceInformation: ["onsite":true]) { (device, error) -> Void in
     	...       
     }
 }

--- a/Sample/Sample/ViewController.swift
+++ b/Sample/Sample/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController {
             return nil
         }
         
-        return FWTNotifiableManager(URL: serverURL, accessId: keys.fWTAccessID(), secretKey: keys.fWTSecretKey(), didRegisterBlock: { [unowned self] (token) -> Void in
+        return FWTNotifiableManager(URL: serverURL, accessId: keys.fWTAccessID(), secretKey: keys.fWTSecretKey(), didRegisterBlock: { [unowned self] (manager, token) -> Void in
             self.registerCompleted?(token: token)
         }, andNotificationBlock: nil)
     }()
@@ -78,7 +78,7 @@ extension ViewController {
     
     private func _registerAnonymousToken(token:NSData) {
         let deviceName = UIDevice.currentDevice().name
-        self.manager.registerAnonymousToken(token, deviceName: deviceName) { (device, error) in
+        self.manager.registerAnonymousDeviceWithName(deviceName, locale: nil, deviceInformation: nil) { (device, error) in
             if let error = error {
                 SVProgressHUD.showErrorWithStatus(error.fwt_localizedMessage())
             } else {
@@ -89,7 +89,7 @@ extension ViewController {
     
     private func _registerToken(token:NSData, user:String) {
         let deviceName = UIDevice.currentDevice().name
-        self.manager.registerToken(token, withUserAlias: user, deviceName: deviceName) { (device, error) in
+        self.manager.registerDeviceWithName(deviceName, userAlias: user, locale: nil, deviceInformation: nil) { (device, error) in
             if let error = error {
                 SVProgressHUD.showErrorWithStatus(error.fwt_localizedMessage())
             } else {


### PR DESCRIPTION
This PR solves the issues:

1. `Pass Notifiable manager into the FWTNotifiableDidRegisterBlock, FWTNotifiableDidReceiveNotificationBlock blocks`

2. `Refactor all registerToken methods --> registerDevice without deviceToken parameter`