### PR TITLE
 Fix the macro to block code for iOS 10

### DIFF
--- a/Notifiable-iOS/FWTNotifiableManager.h
+++ b/Notifiable-iOS/FWTNotifiableManager.h
@@ -51,7 +51,7 @@ NS_SWIFT_NAME(NotifiableManager)
 /** Current device. If the device is not registered, it will be nil. */
 @property (nonatomic, copy, readonly, nullable) FWTNotifiableDevice *currentDevice;
 
-#ifndef __IPHONE_10_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
 /**
  Checks if the user have allowed the application to use push notifications with a specific UIUserNotificationType
  @param types   Notification setting that is expected to be registered

--- a/Notifiable.podspec
+++ b/Notifiable.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 
   s.name         = "Notifiable"
-  s.version      = "1.1.0"
+  s.version      = "1.1.1"
   s.platform     = :ios, '8.0'
   s.summary      = "Utility classes to integrate with Notifiable-Rails gem"
 

--- a/Sample/Podfile.lock
+++ b/Sample/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Keys (1.0.1)
-  - Notifiable (1.1.0)
+  - Notifiable (1.1.1)
   - SVProgressHUD (2.2.5)
 
 DEPENDENCIES:
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Keys: a576f4c9c1c641ca913a959a9c62ed3f215a8de9
-  Notifiable: 9bb30c2b6d75729e157ce7dfc9f853d76b7936d1
+  Notifiable: 30ee974274be265366c196f169b5f7c57fcf362e
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
 
 PODFILE CHECKSUM: c56fea5d7deca27732c80216c41370561c55e3a8


### PR DESCRIPTION
The previous macro was blocking the public method to anyone building on Xcode that supports iOS 10. So, a project on modern compiler, but with support to iOS 9.x or older would not be able to use it. With this fix, now, the project configuration is checked to block/allow the export of this method.