### PR TITLE
Move to URLSession

### DIFF
--- a/Notifiable-iOS/FWTNotifiableManager.h
+++ b/Notifiable-iOS/FWTNotifiableManager.h
@@ -236,6 +236,21 @@ Init a notifiable manager with the configurations of the Notifiable-Rails server
                     andNotificationBlock:(_Nullable FWTNotifiableDidReceiveNotificationBlock)notificationBlock NS_SWIFT_NAME(init(didRegister:didRecieve:));
 
 /**
+Init a notifiable manager with the configurations of the Notifiable-Rails server
+ 
+@see <a href="https://github.com/FutureWorkshops/notifiable-rails">Notifiable-Rails gem</a>
+
+@param urlSession                         NSURLSession used to perform network requests
+@param registerBlock       Block that is called once that the device is registered for receiving notifications
+@param notificationBlock   Block that is called once that the device receives a notification;
+
+@return Manager configured to access a specific Notifiable-Rails server
+*/
+- (instancetype)initWithURLSession:(NSURLSession *)urlSession
+                  didRegisterBlock:(_Nullable FWTNotifiableDidRegisterBlock)registerBlock
+                    andNotificationBlock:(_Nullable FWTNotifiableDidReceiveNotificationBlock)notificationBlock NS_SWIFT_NAME(init(session:didRegister:didRecieve:));
+
+/**
  Init a notifiable manager with the configurations of the Notifiable-Rails server
  
  @see <a href="https://github.com/FutureWorkshops/notifiable-rails">Notifiable-Rails gem</a>
@@ -248,8 +263,24 @@ Init a notifiable manager with the configurations of the Notifiable-Rails server
  */
 - (instancetype)initWithGroupId:(NSString * _Nullable)group
                didRegisterBlock:(_Nullable FWTNotifiableDidRegisterBlock)registerBlock
-           andNotificationBlock:(_Nullable FWTNotifiableDidReceiveNotificationBlock)notificationBlock NS_SWIFT_NAME(init(groupId:didRegister:didRecieve:)) NS_DESIGNATED_INITIALIZER;
+           andNotificationBlock:(_Nullable FWTNotifiableDidReceiveNotificationBlock)notificationBlock NS_SWIFT_NAME(init(groupId:didRegister:didRecieve:));
 
+/**
+ Init a notifiable manager with the configurations of the Notifiable-Rails server
+ 
+ @see <a href="https://github.com/FutureWorkshops/notifiable-rails">Notifiable-Rails gem</a>
+ 
+ @param group                            An string representing the group id in which the SDK saved data will be accessible. If nil, no data is available outside the app.
+ @param urlSession                         NSURLSession used to perform network requests
+ @param registerBlock           Block that is called once that the device is registered for receiving notifications
+ @param notificationBlock   Block that is called once that the device receives a notification;
+ 
+ @return Manager configured to access a specific Notifiable-Rails server
+ */
+- (instancetype)initWithGroupId:(NSString * _Nullable)group
+                     urlSession:(NSURLSession * _Nonnull)urlSession
+               didRegisterBlock:(_Nullable FWTNotifiableDidRegisterBlock)registerBlock
+           andNotificationBlock:(_Nullable FWTNotifiableDidReceiveNotificationBlock)notificationBlock NS_SWIFT_NAME(init(groupId:session:didRegister:didRecieve:)) NS_DESIGNATED_INITIALIZER;
 
 /**
  This method configures the SDK to a specific Notifiable configuration

--- a/Notifiable-iOS/Network/FWTHTTPRequester.h
+++ b/Notifiable-iOS/Network/FWTHTTPRequester.h
@@ -20,6 +20,7 @@ typedef void(^FWTRequestManagerFailureBlock)(NSInteger responseCode, NSError * e
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithBaseURL:(NSURL *)baseUrl
+                        session:(NSURLSession *)session
                andAuthenticator:(FWTNotifiableAuthenticator*)authenticator NS_DESIGNATED_INITIALIZER;
 - (void)registerDeviceWithParams:(NSDictionary *)params
                          success:(_Nullable FWTRequestManagerSuccessBlock)success

--- a/Notifiable-iOS/Network/FWTHTTPRequester.m
+++ b/Notifiable-iOS/Network/FWTHTTPRequester.m
@@ -21,18 +21,20 @@ NSString * const FWTListDevicesPath = @"api/v1/device_tokens.json";
 
 @property (nonatomic, strong) FWTHTTPSessionManager *httpSessionManager;
 @property (nonatomic, strong) FWTNotifiableAuthenticator *authenticator;
+@property (nonatomic, strong) NSURLSession *urlSession;
 
 @end
 
 @implementation FWTHTTPRequester
 
-- (instancetype)initWithBaseURL:(NSURL*)baseUrl
-               andAuthenticator:(FWTNotifiableAuthenticator*)authenticator
-{
+- (instancetype)initWithBaseURL:(NSURL *)baseUrl
+                        session:(NSURLSession *)session
+               andAuthenticator:(FWTNotifiableAuthenticator*)authenticator {
     self = [super init];
     if (self) {
         self->_baseUrl = baseUrl;
         self->_authenticator = authenticator;
+        self->_urlSession = session;
     }
     return self;
 }
@@ -40,7 +42,8 @@ NSString * const FWTListDevicesPath = @"api/v1/device_tokens.json";
 - (FWTHTTPSessionManager *)httpSessionManager
 {
     if (!self->_httpSessionManager) {
-        self->_httpSessionManager = [[FWTHTTPSessionManager alloc] initWithBaseURL:self.baseUrl];
+        self->_httpSessionManager = [[FWTHTTPSessionManager alloc] initWithBaseURL:self.baseUrl
+                                                                           session:self.urlSession];
     }
     return self->_httpSessionManager;
 }

--- a/Notifiable-iOS/Network/FWTHTTPSessionManager.h
+++ b/Notifiable-iOS/Network/FWTHTTPSessionManager.h
@@ -18,7 +18,7 @@ typedef void(^FWTHTTPSessionManagerFailureBlock)(NSInteger responseCode, NSError
 @property (nonatomic, strong, readonly) NSDictionary<NSString *, NSString *> *HTTPRequestHeaders;
 
 - (instancetype) init NS_UNAVAILABLE;
-- (instancetype) initWithBaseURL:(NSURL *)baseUrl NS_DESIGNATED_INITIALIZER;
+- (instancetype) initWithBaseURL:(NSURL *)baseUrl session:(NSURLSession *)session NS_DESIGNATED_INITIALIZER;
 
 - (void)GET:(NSString *)URLString
  parameters:(nullable NSDictionary<NSString *, NSString *> *)parameters

--- a/Notifiable-iOS/Network/FWTHTTPSessionManager.m
+++ b/Notifiable-iOS/Network/FWTHTTPSessionManager.m
@@ -9,6 +9,12 @@
 #import "FWTHTTPSessionManager.h"
 #import "FWTHTTPRequestSerializer.h"
 
+#ifdef DEBUG
+#define NSLog(...) NSLog(__VA_ARGS__)
+#else
+#define NSLog(...)
+#endif
+
 NSString *const FWTHTTPSessionManagerIdentifier = @"com.futureworkshops.notifiable.FWTHTTPSessionManager";
 
 @interface FWTHTTPSessionManager ()
@@ -147,11 +153,11 @@ NSString *const FWTHTTPSessionManagerIdentifier = @"com.futureworkshops.notifiab
 
     __weak typeof(self) weakSelf = self;
     NSURLSessionDataTask *task = [self.urlSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-        NSLog(@"Response with Error: %@", error);
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         
         if (error) {
             failure(httpResponse.statusCode, error);
+            NSLog(@"Response with Error: %@", error);
             return;
         }
         
@@ -159,7 +165,9 @@ NSString *const FWTHTTPSessionManagerIdentifier = @"com.futureworkshops.notifiab
         
         if (httpResponse && (httpResponse.statusCode < 200 || httpResponse.statusCode >= 300)) {
             NSDictionary *userInfo = [responseData isKindOfClass:[NSDictionary class]] ? (NSDictionary *)responseData : @{};
-            failure(404, [NSError errorWithDomain:@"FWTNotifiableError" code:httpResponse.statusCode userInfo:userInfo]);
+            NSError *error = [NSError errorWithDomain:@"FWTNotifiableError" code:httpResponse.statusCode userInfo:userInfo];
+            NSLog(@"Response with Error: %@", error);
+            failure(404, error);
             return;
         }
         

--- a/Notifiable-iOS/Network/FWTRequesterManager.m
+++ b/Notifiable-iOS/Network/FWTRequesterManager.m
@@ -281,7 +281,7 @@ NSString * const FWTNotifiableProvider             = @"apns";
     NSNumber *tokenId = [deviceTokenId copy];
     [self.requester updateDeviceWithTokenId:deviceTokenId params:params success:^(NSDictionary * _Nullable response) {
         __strong typeof(weakSelf) sself = weakSelf;
-        [sself.logger logMessage:@"Did unregister for push notifications"];
+        [sself.logger logMessage:@"Did updated device"];
         if(handler){
             dispatch_async(dispatch_get_main_queue(), ^{
                 handler(tokenId, nil);

--- a/Notifiable.podspec
+++ b/Notifiable.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 
   s.name         = "Notifiable"
-  s.version      = "1.2.5"
+  s.version      = "1.2.6"
   s.platform     = :ios, '10.0'
   s.summary      = "Utility classes to integrate with Notifiable-Rails gem"
 

--- a/Sample/Sample.xcodeproj/xcshareddata/xcschemes/NotificationService.xcscheme
+++ b/Sample/Sample.xcodeproj/xcshareddata/xcschemes/NotificationService.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "78CD0750214BF7C500CCDB08"
+               BuildableName = "NotificationService.appex"
+               BlueprintName = "NotificationService"
+               ReferencedContainer = "container:Sample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7898B8831C56513700BD0CCB"
+               BuildableName = "Sample.app"
+               BlueprintName = "Sample"
+               ReferencedContainer = "container:Sample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "1"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7898B8831C56513700BD0CCB"
+            BuildableName = "Sample.app"
+            BlueprintName = "Sample"
+            ReferencedContainer = "container:Sample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7898B8831C56513700BD0CCB"
+            BuildableName = "Sample.app"
+            BlueprintName = "Sample"
+            ReferencedContainer = "container:Sample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sample/Sample/ViewController.swift
+++ b/Sample/Sample/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
     
     let FWTDeviceListSegue = "FWTDeviceListSegue"
     lazy var manager:NotifiableManager! = {
-        let manager = NotifiableManager(groupId: kAppGroupId, didRegister: { [weak self] (_, token) in
+        let manager = NotifiableManager(groupId: kAppGroupId, session: URLSession.shared, didRegister: { [weak self] (_, token) in
             self?.registerCompleted?(token as NSData)
         }, didRecieve: nil)
         manager.logger = kLogger


### PR DESCRIPTION
This PR removes the use of `sendAsynchronousRequest:queue:completion:` from the network layers, moving to the use of URLSession. The previous call was deprecated on iOS 9.0. Given that, now, the source code is indicated as iOS 10+ only, this should not be used.